### PR TITLE
feat: Updates deprecated division calculations

### DIFF
--- a/src/function/_ratio-percentage.scss
+++ b/src/function/_ratio-percentage.scss
@@ -2,5 +2,5 @@
   @if ($denominator == 0) {
     @return 0;
   }
-  @return calc($numerator / $denominator) * 100 + 0%;
+  @return math.div($numerator, $denominator) * 100 + 0%;
 }

--- a/src/function/_rem.scss
+++ b/src/function/_rem.scss
@@ -4,5 +4,5 @@
   @if ($px == 0) {
     @return 0;
   }
-  @return calc(strip-unit($px) / strip-unit($base)) * 1rem;
+  @return math.div(strip-unit($px), strip-unit($base)) * 1rem;
 }

--- a/src/function/_strip-unit.scss
+++ b/src/function/_strip-unit.scss
@@ -1,3 +1,3 @@
 @function strip-unit($value) {
-  @return calc($value / ($value * 0 + 1));
+  @return math.div($value, ($value * 0 + 1));
 }


### PR DESCRIPTION
Ahead of the release of Dart SASS 2.0, the slash `/` when used as a division operator is being deprecated to bring it in to line with standard CSS syntax where a `/` used solely as a separator. Ahead of this change, instances contained within this module have been updated to use `math.div()` notation instead.
 
**This will be a breaking change:** https://sass-lang.com/documentation/breaking-changes/slash-div